### PR TITLE
Rage Consumption Vignette bug fix.

### DIFF
--- a/src/main/java/it/hurts/octostudios/reliquified_twilight_forest/client/gui/layer/RedVignetteLayer.java
+++ b/src/main/java/it/hurts/octostudios/reliquified_twilight_forest/client/gui/layer/RedVignetteLayer.java
@@ -43,6 +43,8 @@ public class RedVignetteLayer implements LayeredDraw.Layer {
         float partialTick = deltaTracker.getGameTimeDeltaPartialTick(true);
 
         poseStack.pushPose();
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
         RenderSystem.enableBlend();
         RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 
@@ -54,7 +56,9 @@ public class RedVignetteLayer implements LayeredDraw.Layer {
                 .alpha(percentage*0.75f)
                 .end();
 
+        RenderSystem.defaultBlendFunc();
         RenderSystem.disableBlend();
+        RenderSystem.depthMask(true);
         poseStack.popPose();
     }
 }


### PR DESCRIPTION
Fixes issue where the Vignette from Rage Consumption seems to prevent Jade or other gui elements from displaying, as explained in Issue #7 

Tested in Stoneblock 4 by using /relic maximize on Parasite 116, confirming the parasite still showed a vignette and that jade still rendered.